### PR TITLE
Implement a 'tags only' mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Optional:
 - `ensure_available` (boolean) - wait until the AMI becomes available in the copy target account(s)
 - `keep_artifact` (boolean) - remove the original generated AMI after copy (default: true)
 - `manifest_output` (string) - the name of the file we output AMI IDs to, in JSON format (default: no manifest file is written)
+- `tags_only` (boolean) - if set to `true`, then the AMI won't be copied, but the tags will be duplicated on the shared AMI in the destination account.
 
 [packer-doc-plugins]: https://www.packer.io/docs/extending/plugins/#installing-plugins
 [packer-doc-init]: https://www.packer.io/docs/commands/init

--- a/amicopy/amicopy.go
+++ b/amicopy/amicopy.go
@@ -32,6 +32,7 @@ type AmiCopyImpl struct {
 	SourceImage     *ec2.Image
 	EnsureAvailable bool
 	KeepArtifact    bool
+	TagsOnly        bool
 }
 
 // AmiManifest holds the data about the resulting copied image
@@ -48,8 +49,13 @@ func (ac *AmiCopyImpl) Copy(ui *packer.Ui) (err error) {
 		return err
 	}
 
-	if ac.output, err = ac.EC2.CopyImage(ac.input); err != nil {
-		return err
+	if ! ac.TagsOnly {
+		if ac.output, err = ac.EC2.CopyImage(ac.input); err != nil {
+			return err
+		}
+	} else {
+		(*ui).Say(fmt.Sprintf("Only copying tags in %s as tags_only=true", ac.targetAccountID))
+		ac.output = (&ec2.CopyImageOutput{}).SetImageId(*ac.input.SourceImageId)
 	}
 
 	if err = ac.Tag(); err != nil {

--- a/post-processor.go
+++ b/post-processor.go
@@ -52,6 +52,7 @@ type Config struct {
 	EnsureAvailable bool   `mapstructure:"ensure_available"`
 	KeepArtifact    string `mapstructure:"keep_artifact"`
 	ManifestOutput  string `mapstructure:"manifest_output"`
+	TagsOnly        bool   `mapstructure:"tags_only"`
 
 	ctx interpolate.Context
 }
@@ -171,6 +172,7 @@ func (p *PostProcessor) PostProcess(
 				EC2:             conn,
 				SourceImage:     source,
 				EnsureAvailable: p.config.EnsureAvailable,
+				TagsOnly:        p.config.TagsOnly,
 			}
 			amiCopy.SetTargetAccountID(user)
 			amiCopy.SetInput(&ec2.CopyImageInput{
@@ -179,7 +181,7 @@ func (p *PostProcessor) PostProcess(
 				SourceImageId: aws.String(ami.id),
 				SourceRegion:  aws.String(ami.region),
 				KmsKeyId:      aws.String(p.config.AMIKmsKeyId),
-				Encrypted:     aws.Bool(*p.config.AMIEncryptBootVolume.ToBoolPointer()),
+				Encrypted:     aws.Bool(p.config.AMIEncryptBootVolume.True()),
 			})
 
 			copies = append(copies, amiCopy)

--- a/post-processor.hcl2spec.go
+++ b/post-processor.hcl2spec.go
@@ -63,6 +63,7 @@ type FlatConfig struct {
 	EnsureAvailable         *bool                             `mapstructure:"ensure_available" cty:"ensure_available" hcl:"ensure_available"`
 	KeepArtifact            *string                           `mapstructure:"keep_artifact" cty:"keep_artifact" hcl:"keep_artifact"`
 	ManifestOutput          *string                           `mapstructure:"manifest_output" cty:"manifest_output" hcl:"manifest_output"`
+	TagsOnly                *bool                             `mapstructure:"tags_only" cty:"tags_only" hcl:"tags_only"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -128,6 +129,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"ensure_available":              &hcldec.AttrSpec{Name: "ensure_available", Type: cty.Bool, Required: false},
 		"keep_artifact":                 &hcldec.AttrSpec{Name: "keep_artifact", Type: cty.String, Required: false},
 		"manifest_output":               &hcldec.AttrSpec{Name: "manifest_output", Type: cty.String, Required: false},
+		"tags_only":                     &hcldec.AttrSpec{Name: "tags_only", Type: cty.Bool, Required: false},
 	}
 	return s
 }


### PR DESCRIPTION
I'm quite comfortable with EC2's "shared AMI" model, where you only pay for
the storage in one place, but I do like to have my images well-tagged.  This
change adds a `tags_only` flag that can be used to make sure that happens.

Also had to correct a call to `ToBoolPointer()` because it was causing the
plugin to segfault on a null pointer without it.