### PR TITLE
fix: added missing goreleaser version 2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
           go-version: 1.22
       - name: Describe plugin
         id: plugin_describe
-        run: echo "::set-output name=api_version::$(go run . describe | jq -r '.api_version')"
+        run: echo "name=api_version::$(go run . describe | jq -r '.api_version')" >> $GITHUB_OUTPUT
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 env:
   - CGO_ENABLED=0
 
@@ -10,7 +12,7 @@ builds:
       post:
         # This will check plugin compatibility against latest version of Packer
         - cmd: |
-            go install github.com/hashicorp/packer/cmd/packer-plugins-check@latest &&
+            go install github.com/hashicorp/packer/cmd/packer-plugins-check@v1.7.10 &&
             packer-plugins-check -load={{ .Name }}
           dir: "{{ dir .Path}}"
     flags:
@@ -52,4 +54,15 @@ checksum:
   algorithm: sha256
 release:
 changelog:
-  skip: true
+  sort: asc
+  use: github
+  filters:
+    exclude:
+      - "^test:"
+      - "^test\\("
+      - "merge conflict"
+      - Merge pull request
+      - Merge remote-tracking branch
+      - Merge branch
+      - go mod tidy
+


### PR DESCRIPTION
I've fixed the goreleaser (see https://github.com/martinbaillie/packer-plugin-ami-copy/actions/runs/10017183435).