### PR TITLE
fix: set draft to false to publish release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22
+          go-version-file: 'go.mod'
       - name: Describe plugin
         id: plugin_describe
         run: echo "name=api_version::$(go run . describe | jq -r '.api_version')" >> $GITHUB_OUTPUT

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -59,7 +59,7 @@ snapshot:
   name_template: "{{ incpatch .Version }}-rc"
 
 release:
-  draft: true
+  draft: false
 
 changelog:
   sort: asc


### PR DESCRIPTION
> If set to true, will not auto-publish the release.
> Note: all GitHub releases start as drafts while artifacts are uploaded.
> Available only for GitHub and Gitea.

Source: https://goreleaser.com/customization/release/