### PR TITLE
chore: update version to v1.9.4 release

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 
 var (
 	// TODO: LD flags.
-	Version           = "1.9.0"
+	Version           = "1.9.4"
 	VersionPrerelease = ""
 	PluginVersion     = version.NewPluginVersion(Version, VersionPrerelease, "")
 )


### PR DESCRIPTION
Hey, last thing... I can't install the new plugin, because there is a version mismatch. I've bumped to the next tag. 
Could You then please create a v1.9.4 release. This should work then, thanks.