### PR TITLE
Fix binary naming for linux amd64 asset

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,6 +39,7 @@ builds:
             go install github.com/hashicorp/packer/cmd/packer-plugins-check@v1.7.10 &&
             packer-plugins-check -load={{ .Name }}
           dir: "{{ dir .Path}}"
+    binary: '{{ .ProjectName }}_v{{ .Version }}_{{ .Env.API_VERSION }}_{{ .Os }}_{{ .Arch }}'
 
 archives:
   - format: zip


### PR DESCRIPTION
This PR fixes issue https://github.com/martinbaillie/packer-plugin-ami-copy/issues/115

Local output:

```
command: goreleaser release --clean --snapshot

```
<img width="445" alt="Screenshot 2024-08-06 at 5 58 42 PM" src="https://github.com/user-attachments/assets/1bd108c8-c341-45a4-93b7-72c668ae79e4">


the version should be upto date when the git workflow is run