### PR TITLE
Bump version number to match the release

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 
 var (
 	// TODO: LD flags.
-	Version           = "1.9.4"
+	Version           = "1.9.6"
 	VersionPrerelease = ""
 	PluginVersion     = version.NewPluginVersion(Version, VersionPrerelease, "")
 )


### PR DESCRIPTION
$ ./packer init test.hcl
Failed getting the "github.com/martinbaillie/ami-copy" plugin:
2 errors occurred:
	* Continuing to next available version: binary reported version ("1.9.4") is different from the expected "1.9.5", skipping
	* could not install any compatible version of plugin "github.com/martinbaillie/ami-copy"

It looks like the version bump was forgotten in the 1.9.5 release.